### PR TITLE
Fix mistranslation.

### DIFF
--- a/string-constants-lib/string-constants/private/spanish-string-constants.rkt
+++ b/string-constants-lib/string-constants/private/spanish-string-constants.rkt
@@ -980,7 +980,7 @@
  (stepper-previous "Paso")
  (stepper-next "Paso")
  (stepper-next-application "Aplicación")
- (stepper-jump-to-beginning "Hogar")
+ (stepper-jump-to-beginning "al inicio")
  
  (dialog-back "Atrás")
  


### PR DESCRIPTION
This change fixes a mistranslation in the Spanish localization of the Stepper.