### PR TITLE
Fix German translation

### DIFF
--- a/string-constants-lib/string-constants/private/german-string-constants.rkt
+++ b/string-constants-lib/string-constants/private/german-string-constants.rkt
@@ -1329,7 +1329,7 @@
  
  ;; test coverage
  (test-coverage-clear? "Änderungen im Definitionsfenster machen die Information über Testabdeckung ungültig. Weitermachen?")
- (test-coverage-clear-and-do-not-ask-again "Ja, und nicht nicht wieder fragen")
+ (test-coverage-clear-and-do-not-ask-again "Ja, und nicht noch einmal fragen")
  (test-coverage-ask? "Frage nach dem Löschen der Testabdeckungs-Information")
  (test-coverage-on "Durch Tests abgedeckt")
  (test-coverage-off "Durch Tests nicht abgedeckt")


### PR DESCRIPTION
The repeated `nicht` is clearly wrong. I studied German a long time ago in primary school, so I think that just removing the repeated `nicht` doesn't sound good, but I'm not sure. I copied the translation from another line (with the obvious changes), but I'm also not sure this is better.

Note that the equivalent sentence in English is https://github.com/racket/string-constants/blob/45d53fadf552ecbe89e72b0ef76f129b838acd98/string-constants-lib/string-constants/private/english-string-constants.rkt#L1555

