### PR TITLE
add license to package info.rkt files

### DIFF
--- a/string-constants-doc/info.rkt
+++ b/string-constants-doc/info.rkt
@@ -8,3 +8,6 @@
 (define update-implies '("string-constants-lib"))
 
 (define pkg-authors '(robby))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/string-constants-lib-lgpl/info.rkt
+++ b/string-constants-lib-lgpl/info.rkt
@@ -8,3 +8,6 @@
 (define pkg-authors '(robby))
 
 (define version "1.1")
+
+(define license
+  'LGPL-2.0-or-later)

--- a/string-constants-lib/info.rkt
+++ b/string-constants-lib/info.rkt
@@ -8,3 +8,6 @@
 (define pkg-authors '(robby))
 
 (define version "1.38")
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/string-constants/info.rkt
+++ b/string-constants/info.rkt
@@ -10,3 +10,6 @@
 (define pkg-desc "String constants to support internationalization, especially in DrRacket")
 
 (define pkg-authors '(robby))
+
+(define license
+  '(Apache-2.0 OR MIT))


### PR DESCRIPTION
related to https://github.com/racket/racket/pull/3760

Note the use of `'LGPL-2.0-or-later` for `string-constants-lgpl`.